### PR TITLE
Updated PyPI Publishing Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,5 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          skip-existing: true
           password: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ConvexTrader"
-version = "0.0.0"
+version = "0.0.1"
 description = "A package for portfolio optimization using convex optimization"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def parse_requirements(filename):
 
 setup(
     name="ConvexTrader",
-    version="0.0.0",
+    version="0.0.1",
     author="Liam Davis",
     author_email="ljdavis27@amherst.edu",
     description="A package for portfolio optimization using convex optimization",


### PR DESCRIPTION
This pull request includes several changes to the versioning and publishing configuration of the `ConvexTrader` package. The most important changes are summarized below:

Version updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the package version from `0.0.0` to `0.0.1`.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L18-R18): Updated the package version from `0.0.0` to `0.0.1`.

Publishing configuration:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R37): Added the `skip-existing: true` option to the PyPI publish step to avoid errors when the package version already exists.