### PR TITLE
Update Sphinx Workflow to use root requirements

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -18,10 +18,11 @@ jobs:
 
       # Install dependencies including Django and Sphinx
       - name: Install dependencies
-        working-directory: ./docs
+        working-directory: ./
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -e .
 
       # Build the HTML using Sphinx
       - name: Build HTML

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-sphinx==8.1.3
-furo


### PR DESCRIPTION
This pull request includes changes to the Sphinx documentation setup and dependency management. The most important changes are:

Dependency management:

* [`.github/workflows/sphinx.yml`](diffhunk://#diff-3b5400f13c20505910b5f51111b34c0c17ad7137e82e2859cef6ee5a09e77f8dL21-R25): Updated the working directory for installing dependencies and added the installation of the current package in editable mode.

Documentation dependencies:

* [`docs/requirements.txt`](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90L1-L2): Removed specific Sphinx version and the Furo theme from the requirements.…d remove docs requirements file